### PR TITLE
Test K8s versions 1.18, 1.19, and 1.20

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         globalnet: ['', 'globalnet']
+        k8s_version: ['1.17.17']
         lighthouse: ['', 'lighthouse']
         ovn: ['', 'ovn']
         exclude:
@@ -20,6 +21,11 @@ jobs:
             lighthouse: 'lighthouse'
           - ovn: 'ovn'
             globalnet: 'globalnet'
+        include:
+          # Recentness of K8s versions are limited by kindest/node image releases
+          - k8s_version: 1.18.15
+          - k8s_version: 1.19.7
+          - k8s_version: 1.20.2
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
@@ -27,6 +33,7 @@ jobs:
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
+          k8s_version: ${{ matrix.k8s_version }}
           using: ${{ matrix.globalnet }} ${{ matrix.lighthouse }} ${{ matrix.ovn }}
 
       - name: Post mortem


### PR DESCRIPTION
Use the new abilty of the shared E2E GHA to configure the version of
Kubernetes. Add jobs that cover the latest aviable patch versions
(limited by KIND images) from the three most recent minor versions.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>